### PR TITLE
small typo in included filename: LCD_2IN.h -> LCD_2in.h

### DIFF
--- a/c/examples/LCD_2in_test.c
+++ b/c/examples/LCD_2in_test.c
@@ -28,7 +28,7 @@
 #
 ******************************************************************************/
 #include "EPD_Test.h"
-#include "LCD_2IN.h"
+#include "LCD_2in.h"
 
 bool reserved_addr(uint8_t addr) {
 return (addr & 0x78) == 0 || (addr & 0x78) == 0x78;

--- a/c/lib/LCD/LCD_2in.c
+++ b/c/lib/LCD/LCD_2in.c
@@ -11,7 +11,7 @@
 * | Info        :   Basic version
 *
 ******************************************************************************/
-#include "LCD_2IN.h"
+#include "LCD_2in.h"
 #include "DEV_Config.h"
 
 #include <stdlib.h>		//itoa()


### PR DESCRIPTION
fix typo mentioned in https://github.com/waveshare/Pico_code/issues/2#issue-898831576