### PR TITLE
fix: include statement for LCD_2in.h

### DIFF
--- a/c/lib/LCD/LCD_2in.c
+++ b/c/lib/LCD/LCD_2in.c
@@ -11,7 +11,7 @@
 * | Info        :   Basic version
 *
 ******************************************************************************/
-#include "LCD_2IN.h"
+#include "LCD_2in.h"
 #include "DEV_Config.h"
 
 #include <stdlib.h>		//itoa()


### PR DESCRIPTION
The current `#include "LCD_2IN.h"` is wrong because the include file is `LCD_2in.h` with the lowercase "in". This fix just correct this in order to be compiled in case-sensitive environment like GNU/Linux.