### PR TITLE
Add pull-up for joystick/buttons

### DIFF
--- a/Python/Pico-LCD-1.14/Pico-LCD-1.14.py
+++ b/Python/Pico-LCD-1.14/Pico-LCD-1.14.py
@@ -179,10 +179,10 @@ if __name__=='__main__':
     LCD.rect(208,103,20,20,LCD.red)
     
     LCD.show()
-    key0 = Pin(15,Pin.IN)
-    key1 = Pin(17,Pin.IN)
-    key2 = Pin(2 ,Pin.IN)
-    key3 = Pin(3 ,Pin.IN)
+    key0 = Pin(15,Pin.IN, Pin.PULL_UP)
+    key1 = Pin(17,Pin.IN, Pin.PULL_UP)
+    key2 = Pin(2 ,Pin.IN, Pin.PULL_UP)
+    key3 = Pin(3 ,Pin.IN, Pin.PULL_UP)
     while(1):
         if(key0.value() == 0):
             LCD.fill_rect(12,12,20,20,LCD.red)


### PR DESCRIPTION
With the current demo, the joystick/button inputs are floating and will result in unreliable "flickering" of the red squares.

Pulling the GPIO pins up using `Pin.PULL_UP` will prevent this flickering. "Up", because looking at the [schematic of the V2 version which I have](https://files.waveshare.com/upload/6/61/Pico-LCD-1.14-V2-SchDoc.pdf), the buttons are switching to ground. Thus, requiring a pull-up resistor (built-in or not).

Also:

* Other boards might also benefit from this, but I only checked the schematic of the 1.14" board as that's the one I have;
* You might wanna fix the typo in the `Pico_code` repository, which currently is "Waveshrae Pico-OLED/LCD driver code" (notice the incorrect spelling of "Waveshare").